### PR TITLE
Use u32 in wasm FFI instead of casting to f32

### DIFF
--- a/js/sapp_jsutils.js
+++ b/js/sapp_jsutils.js
@@ -28,6 +28,12 @@ register_plugin = function (importObject) {
         js_objects[js_object][field] = data;
     }
 
+    importObject.env.js_set_field_u32 = function (js_object, buf, max_len, data) {
+        var field = UTF8ToString(buf, max_len);
+
+        js_objects[js_object][field] = data;
+    }
+
     importObject.env.js_set_field_string = function (js_object, buf, max_len, data_buf, data_len) {
         var field = UTF8ToString(buf, max_len);
         var data = UTF8ToString(data_buf, data_len);
@@ -77,7 +83,13 @@ register_plugin = function (importObject) {
         return js_objects[js_object][field_name] !== undefined;
     }
 
-    importObject.env.js_field_num = function (js_object, buf, length) {
+    importObject.env.js_field_f32 = function (js_object, buf, length) {
+        var field_name = UTF8ToString(buf, length);
+
+        return js_objects[js_object][field_name];
+    }
+
+    importObject.env.js_field_u32 = function (js_object, buf, length) {
         var field_name = UTF8ToString(buf, length);
 
         return js_objects[js_object][field_name];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,10 @@ extern "C" {
     fn js_field(js_object: JsObjectWeak, buf: *mut u8, len: u32) -> JsObject;
 
     /// Get a numerical value of .field or ["field"] of given JsObject
-    fn js_field_num(js_object: JsObjectWeak, buf: *mut u8, len: u32) -> f32;
+    fn js_field_f32(js_object: JsObjectWeak, buf: *mut u8, len: u32) -> f32;
+
+    /// Get a u32 value of .field or ["field"] of given JsObject
+    fn js_field_u32(js_object: JsObjectWeak, buf: *mut u8, len: u32) -> u32;
 
     /// Set .field or ["field"] to given string, like "object.field = "data"";
     fn js_set_field_string(
@@ -80,6 +83,9 @@ extern "C" {
 
     /// Set .field or ["field"] to given f32, like "object.field = data";
     fn js_set_field_f32(js_object: JsObjectWeak, buf: *mut u8, len: u32, data: f32);
+
+    /// Set .field or ["field"] to given u32, like "object.field = data";
+    fn js_set_field_u32(js_object: JsObjectWeak, buf: *mut u8, len: u32, data: u32);
 
 }
 
@@ -130,7 +136,7 @@ impl JsObject {
     /// Get a value from this object .field
     /// Will panic if self is not an object or map
     pub fn field_u32(&self, field: &str) -> u32 {
-        unsafe { js_field_num(self.weak(), field.as_ptr() as _, field.len() as _) as u32 }
+        unsafe { js_field_u32(self.weak(), field.as_ptr() as _, field.len() as _) }
     }
 
     /// .field == undefined
@@ -141,13 +147,19 @@ impl JsObject {
     /// Get a value from this object .field
     /// Will panic if self is not an object or map
     pub fn field_f32(&self, field: &str) -> f32 {
-        unsafe { js_field_num(self.weak(), field.as_ptr() as _, field.len() as _) }
+        unsafe { js_field_f32(self.weak(), field.as_ptr() as _, field.len() as _) }
     }
 
     /// Set .field or ["field"] to given f32, like "object.field = data";
     /// Will panic if self is not an object or map
     pub fn set_field_f32(&self, field: &str, data: f32) {
         unsafe { js_set_field_f32(self.weak(), field.as_ptr() as _, field.len() as _, data) }
+    }
+
+    /// Set .field or ["field"] to given u32, like "object.field = data";
+    /// Will panic if self is not an object or map
+    pub fn set_field_u32(&self, field: &str, data: u32) {
+        unsafe { js_set_field_u32(self.weak(), field.as_ptr() as _, field.len() as _, data) }
     }
 
     /// Set .field or ["field"] to given string, like "object.field = data";


### PR DESCRIPTION
if you cast over f32, it's not a perfect transition across the FFI boundary, as you may lose some digits if your u32 is large enough.