### PR TITLE
Automatically process undef and null in js_object.

### DIFF
--- a/js/sapp_jsutils.js
+++ b/js/sapp_jsutils.js
@@ -28,6 +28,12 @@ register_plugin = function (importObject) {
         js_objects[js_object][field] = data;
     }
 
+    importObject.env.js_set_field_u32 = function (js_object, buf, max_len, data) {
+        var field = UTF8ToString(buf, max_len);
+
+        js_objects[js_object][field] = data;
+    }
+
     importObject.env.js_set_field_string = function (js_object, buf, max_len, data_buf, data_len) {
         var field = UTF8ToString(buf, max_len);
         var data = UTF8ToString(data_buf, data_len);
@@ -77,7 +83,13 @@ register_plugin = function (importObject) {
         return js_objects[js_object][field_name] !== undefined;
     }
 
-    importObject.env.js_field_num = function (js_object, buf, length) {
+    importObject.env.js_field_f32 = function (js_object, buf, length) {
+        var field_name = UTF8ToString(buf, length);
+
+        return js_objects[js_object][field_name];
+    }
+
+    importObject.env.js_field_u32 = function (js_object, buf, length) {
         var field_name = UTF8ToString(buf, length);
 
         return js_objects[js_object][field_name];

--- a/js/sapp_jsutils.js
+++ b/js/sapp_jsutils.js
@@ -1,6 +1,8 @@
 var ctx = null;
 
 js_objects = {}
+js_objects[-1] = null;
+js_objects[-2] = undefined;
 unique_js_id = 0
 
 register_plugin = function (importObject) {
@@ -144,6 +146,12 @@ function toUTF8Array(str) {
 // And let Rust keep ownership of this reference
 // There is no guarantees on JS side of this reference uniqueness, its good idea to use this only on rust functions arguments
 function js_object(obj) {
+    if (obj == undefined) {
+        return -2;
+    }
+    if (obj === null) {
+        return -1;
+    }
     var id = unique_js_id;
 
     js_objects[id] = obj;

--- a/js/sapp_jsutils.js
+++ b/js/sapp_jsutils.js
@@ -102,12 +102,7 @@ register_plugin = function (importObject) {
         // apparently .field and ["field"] is the same thing in js
         var field = js_objects[js_object][field_name];
 
-        var id = unique_js_id
-        js_objects[id] = field
-
-        unique_js_id += 1;
-
-        return id;
+        return js_object(field);
     }
 }
 miniquad_add_plugin({ register_plugin, version: "0.1.5", name: "sapp_jsutils" });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,10 @@ extern "C" {
     fn js_field(js_object: JsObjectWeak, buf: *mut u8, len: u32) -> JsObject;
 
     /// Get a numerical value of .field or ["field"] of given JsObject
-    fn js_field_num(js_object: JsObjectWeak, buf: *mut u8, len: u32) -> f32;
+    fn js_field_f32(js_object: JsObjectWeak, buf: *mut u8, len: u32) -> f32;
+
+    /// Get a u32 value of .field or ["field"] of given JsObject
+    fn js_field_u32(js_object: JsObjectWeak, buf: *mut u8, len: u32) -> u32;
 
     /// Set .field or ["field"] to given string, like "object.field = "data"";
     fn js_set_field_string(
@@ -80,6 +83,9 @@ extern "C" {
 
     /// Set .field or ["field"] to given f32, like "object.field = data";
     fn js_set_field_f32(js_object: JsObjectWeak, buf: *mut u8, len: u32, data: f32);
+
+    /// Set .field or ["field"] to given u32, like "object.field = data";
+    fn js_set_field_u32(js_object: JsObjectWeak, buf: *mut u8, len: u32, data: u32);
 
 }
 
@@ -130,7 +136,7 @@ impl JsObject {
     /// Get a value from this object .field
     /// Will panic if self is not an object or map
     pub fn field_u32(&self, field: &str) -> u32 {
-        unsafe { js_field_num(self.weak(), field.as_ptr() as _, field.len() as _) as u32 }
+        unsafe { js_field_u32(self.weak(), field.as_ptr() as _, field.len() as _) }
     }
 
     /// .field == undefined
@@ -141,13 +147,19 @@ impl JsObject {
     /// Get a value from this object .field
     /// Will panic if self is not an object or map
     pub fn field_f32(&self, field: &str) -> f32 {
-        unsafe { js_field_num(self.weak(), field.as_ptr() as _, field.len() as _) }
+        unsafe { js_field_f32(self.weak(), field.as_ptr() as _, field.len() as _) }
     }
 
     /// Set .field or ["field"] to given f32, like "object.field = data";
     /// Will panic if self is not an object or map
     pub fn set_field_f32(&self, field: &str, data: f32) {
         unsafe { js_set_field_f32(self.weak(), field.as_ptr() as _, field.len() as _, data) }
+    }
+
+    /// Set .field or ["field"] to given u32, like "object.field = data";
+    /// Will panic if self is not an object or map
+    pub fn set_field_u32(&self, field: &str, data: u32) {
+        unsafe { js_set_field_u32(self.weak(), field.as_ptr() as _, field.len() as _, data) }
     }
 
     /// Set .field or ["field"] to given string, like "object.field = data";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,12 +177,16 @@ impl JsObject {
         }
     }
 
-    /// JS function returning JsObject may return -1 instead.
-    /// Those JsObject are considering nil and if function may do this JsObjects
-    /// should be checked for nil.
-    /// Unfortunately this is not typecheked by rust complier at all,
-    /// so any "f() -> JsObject" function may return nil
+    /// Checks whether the JsObject handle is actually null
     pub fn is_nil(&self) -> bool {
-        self.0 == -1
+        self.0 == Self::NULL.0
     }
+
+    /// Checks whether the JsObject handle is undefined
+    pub fn is_undefined(&self) -> bool {
+        self.0 == Self::UNDEFINED.0
+    }
+
+    pub const NULL: Self = Self(-1);
+    pub const UNDEFINED: Self = Self(-2);
 }


### PR DESCRIPTION
Instead of requiring the user to manually return -1, we detect null automatically in js_object and don't allocate an id for it.

Also add a method for detecting undefinedness (cc #1).